### PR TITLE
[Hotfix] Using terminal name instead OS

### DIFF
--- a/_apply-colors.sh
+++ b/_apply-colors.sh
@@ -13,12 +13,11 @@ function gnome_color () {
 }
 
 # |
-# | Check for OS and decide how to apply
+# | Check for the terminal name and decide how to apply
 # | ===========================================
-if [ $(lsb_release -c -s) = "freya" ]; then
-
+if [ $(ps -p $(ps -p $(ps -p $$ -o ppid=) -o ppid=) -o args=) = "pantheon-terminal" ]; then
     # |
-    # | Apply Variables
+    # | Applying values on pantheon-terminal
     # | ===========================================
     gsettings set org.pantheon.terminal.settings background "${BACKGROUND_COLOR}"
     gsettings set org.pantheon.terminal.settings foreground "${FOREGROUND_COLOR}"
@@ -26,9 +25,8 @@ if [ $(lsb_release -c -s) = "freya" ]; then
     gsettings set org.pantheon.terminal.settings palette "${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}"
 
 else
-
     # |
-    # | Set gnome Variables
+    # | Applying values on gnome-terminal
     # | ===========================================
     BACKGROUND_COLOR=$(gnome_color $BACKGROUND_COLOR)
     FOREGROUND_COLOR=$(gnome_color $FOREGROUND_COLOR)


### PR DESCRIPTION
I'm at elementaryOS but I don't use pantheon-terminal. The current script try to change based on my OS, instead on which terminal I'm actually using.

Changed this and now the script try to infer the terminal being used.