### PR TITLE
Problem with text exhibition on htop when using Solarized Dark theme

### DIFF
--- a/themes/solarized.dark.sh
+++ b/themes/solarized.dark.sh
@@ -10,7 +10,7 @@ COLOR_06="#D33682"           # SYNTAX_VAR
 COLOR_07="#2AA198"           # PROMP
 COLOR_08="#EEE8D5"           #
 
-COLOR_09="#002B36"           #
+COLOR_09="#657B83"           #
 COLOR_10="#D87979"           # COMMAND_ERROR
 COLOR_11="#88CF76"           # EXEC
 COLOR_12="#657B83"           #


### PR DESCRIPTION
The previous state of Solarized Dark color scheme was making part of the info shown on htop go missing because a text color was set to the same color as terminal background as you can check down below:

Old state of the color scheme:
![terminal](https://user-images.githubusercontent.com/5861625/27249771-f9f4ca0c-52ea-11e7-8615-076734e80dfb.png)

New state of the color scheme:
![terminal-fixed](https://user-images.githubusercontent.com/5861625/27249772-01b311cc-52eb-11e7-9d10-64d7da7aa0ae.png)

