### PR TITLE
add support for mate-terminal

### DIFF
--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -12,6 +12,49 @@ function gnome_color () {
     echo "#${AA}${AA}${BB}${BB}${CC}${CC}"
 }
 
+dset() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    if [[ "$type" == "string" ]]; then
+        val="'$val'"
+    fi
+
+    "$DCONF" write "$PROFILE_KEY/$key" "$val"
+}
+
+# because dconf still doesn't have "append"
+dlist_append() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+            {
+                "$DCONF" read "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+                echo "'$val'"
+            } | head -c-1 | tr "\n" ,
+        )"
+
+    "$DCONF" write "$key" "[$entries]"
+}
+
+set_theme() {
+    dset visible-name "'$PROFILE_NAME'"
+    dset palette "'${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}'"
+    dset background-color "'${BACKGROUND_COLOR}'"
+    dset foreground-color "'${FOREGROUND_COLOR}'"
+    if [ ! -z "${BOLD_COLOR}" ]; then
+        dset bold-color "'${BOLD_COLOR}'"
+        dset bold-color-same-as-fg "false"
+    else
+        dset bold-color "'${COLOR_08}'"
+        dset bold-color-same-as-fg "true"
+    fi
+    dset use-theme-colors "false"
+    dset use-theme-background "false"
+}
+
+
 # |
 # | Check for the terminal name and decide how to apply
 # | ===========================================
@@ -24,6 +67,41 @@ if [ $TERMINAL = "pantheon-terminal" ]; then
     gsettings set org.pantheon.terminal.settings foreground "${FOREGROUND_COLOR}"
     gsettings set org.pantheon.terminal.settings cursor-color "${CURSOR_COLOR}"
     gsettings set org.pantheon.terminal.settings palette "${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}"
+
+elif [ $TERMINAL = "mate-terminal" ]; then
+    # |
+    # | Applying values on pantheon-terminal
+    # | ===========================================
+
+    [[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Default"
+    [[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG=`uuidgen`
+    [[ -z "$DCONF" ]] && DCONF=dconf
+
+    BASE_DIR=/org/mate/terminal
+    PROFILE_DIR="$BASE_DIR/profiles"
+
+    if [[ -n "`$DCONF read $BASE_DIR/global/default-profile`" ]]; then
+        DEFAULT_SLUG=`$DCONF read $BASE_DIR/global/default-profile | tr -d \'`
+    else
+        DEFAULT_SLUG=`$DCONF list $PROFILE_DIR/ | head -n1 | tr -d \/`
+    fi
+
+    DEFAULT_KEY="$PROFILE_DIR/$DEFAULT_SLUG"
+    PROFILE_KEY="$PROFILE_DIR/$PROFILE_SLUG"
+
+    # copy existing settings from default profile
+    dconf dump "$DEFAULT_KEY/" | dconf load "$PROFILE_KEY/"
+
+    # add new copy to list of profiles
+    dlist_append $PROFILE_DIR/list "$PROFILE_SLUG"
+
+    # add new copy to global list of profiles
+    dlist_append $BASE_DIR/global/profile-list "$PROFILE_SLUG"
+
+    set_theme
+
+    exit 0
+
 
 else
     # |
@@ -58,32 +136,6 @@ else
     [[ -z "$DCONF" ]] && DCONF=dconf
     [[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen
 
-    dset() {
-        local key="$1"; shift
-        local val="$1"; shift
-
-        if [[ "$type" == "string" ]]; then
-            val="'$val'"
-        fi
-
-        "$DCONF" write "$PROFILE_KEY/$key" "$val"
-    }
-
-    # because dconf still doesn't have "append"
-    dlist_append() {
-        local key="$1"; shift
-        local val="$1"; shift
-
-        local entries="$(
-            {
-                "$DCONF" read "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
-                echo "'$val'"
-            } | head -c-1 | tr "\n" ,
-        )"
-
-        "$DCONF" write "$key" "[$entries]"
-    }
-
     # Newest versions of gnome-terminal use dconf
     if which "$DCONF" > /dev/null 2>&1; then
         [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
@@ -109,19 +161,7 @@ else
             dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
 
             # update profile values with theme options
-            dset visible-name "'$PROFILE_NAME'"
-            dset palette "['${COLOR_01}', '${COLOR_02}', '${COLOR_03}', '${COLOR_04}', '${COLOR_05}', '${COLOR_06}', '${COLOR_07}', '${COLOR_08}', '${COLOR_09}', '${COLOR_10}', '${COLOR_11}', '${COLOR_12}', '${COLOR_13}', '${COLOR_14}', '${COLOR_15}', '${COLOR_16}']"
-            dset background-color "'${BACKGROUND_COLOR}'"
-            dset foreground-color "'${FOREGROUND_COLOR}'"
-            if [ ! -z "${BOLD_COLOR}" ]; then
-              dset bold-color "'${BOLD_COLOR}'"
-              dset bold-color-same-as-fg "false"
-            else
-              dset bold-color "'${COLOR_08}'"
-              dset bold-color-same-as-fg "true"
-            fi
-            dset use-theme-colors "false"
-            dset use-theme-background "false"
+	    set_theme
 
             unset PROFILE_NAME
             unset PROFILE_SLUG

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -99,6 +99,7 @@ elif [ $TERMINAL = "mate-terminal" ]; then
 
     set_theme
     dset palette "'${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}'"
+    dset allow-bold "true"
 
     exit 0
 

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -40,7 +40,6 @@ dlist_append() {
 
 set_theme() {
     dset visible-name "'$PROFILE_NAME'"
-    dset palette "'${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}'"
     dset background-color "'${BACKGROUND_COLOR}'"
     dset foreground-color "'${FOREGROUND_COLOR}'"
     if [ ! -z "${BOLD_COLOR}" ]; then
@@ -99,6 +98,7 @@ elif [ $TERMINAL = "mate-terminal" ]; then
     dlist_append $BASE_DIR/global/profile-list "$PROFILE_SLUG"
 
     set_theme
+    dset palette "'${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}'"
 
     exit 0
 
@@ -162,6 +162,7 @@ else
 
             # update profile values with theme options
 	    set_theme
+	    dset palette "['${COLOR_01}', '${COLOR_02}', '${COLOR_03}', '${COLOR_04}', '${COLOR_05}', '${COLOR_06}', '${COLOR_07}', '${COLOR_08}', '${COLOR_09}', '${COLOR_10}', '${COLOR_11}', '${COLOR_12}', '${COLOR_13}', '${COLOR_14}', '${COLOR_15}', '${COLOR_16}']"
 
             unset PROFILE_NAME
             unset PROFILE_SLUG


### PR DESCRIPTION
This pull request adds mate-terminal support as requested in issue #37. 

The user must have dconf-cli installed.