### PR TITLE
Update gruvbox-dark.sh

### DIFF
--- a/themes/gruvbox-dark.sh
+++ b/themes/gruvbox-dark.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
 # ====================CONFIG THIS =============================== #
-COLOR_01="#665c54"          # HOST
-COLOR_02="#fb4934"          # SYNTAX_STRING
-COLOR_03="#83a598"          # COMMAND
+COLOR_01="#282828"          # HOST
+COLOR_02="#cc241d"          # SYNTAX_STRING
+COLOR_03="#98971a"          # COMMAND
 COLOR_04="#d79921"          # COMMAND_COLOR2
-COLOR_05="#b16286"          # PATH
-COLOR_06="#458588"          # SYNTAX_VAR
-COLOR_07="#b8bb26"          # PROMP
-COLOR_08="#d65d0e"          #
+COLOR_05="#458588"          # PATH
+COLOR_06="#b16286"          # SYNTAX_VAR
+COLOR_07="#689d6a"          # PROMP
+COLOR_08="#a89984"          #
 
-COLOR_09="#a89984"          #
+COLOR_09="#928374"          #
 COLOR_10="#fb4934"          # COMMAND_ERROR
-COLOR_11="#8ec07c"          # EXEC
+COLOR_11="#b8bb26"          # EXEC
 COLOR_12="#fabd2f"          #
-COLOR_13="#d3869b"          # FOLDER
-COLOR_14="#689d6a"          #
-COLOR_15="#98971a"          #
-COLOR_16="#fe8019"          #
+COLOR_13="#83a598"          # FOLDER
+COLOR_14="#d3869b"          #
+COLOR_15="#8ec07c"          #
+COLOR_16="#ebdbb2"          #
 
 BACKGROUND_COLOR="#282828"  # Background Color
 FOREGROUND_COLOR="#ebdbb2"  # Text


### PR DESCRIPTION
Now gruvbox-dark is based on actual Gruvbox, as opposed to the variant of Gruvbox that happened to look good on the original user's machine. IMO, all configuration should be based on standard color palette order (such as "color 0" should be the background color and "color 1" should be semantically "light" red). The previous color scheme used the old palette, but ordered it somewhat randomly, with a blue in the "green" spot, purple in the "blue" spot, etc. Not sure exactly what was happening, but I believe this solves it.