### PR TITLE
Gogh: Improvements

### DIFF
--- a/gogh.sh
+++ b/gogh.sh
@@ -221,7 +221,6 @@ for OP in "${OPTION[@]}"; do
         echo "Theme: ${FILENAME_SPACE^}"
         SET_THEME="${THEMES[((OP-1))]}"
         set_gogh "${SET_THEME}"
-        exit 1
     else
         echo -e "\\e[0m\e[0;31m ~ INVALID OPTION! ~\\e[0m\e[0m"
         exit 1

--- a/gogh.sh
+++ b/gogh.sh
@@ -216,8 +216,10 @@ read -p 'Enter OPTION(S) : ' -a OPTION
 for OP in "${OPTION[@]}"; do
 
     if (( OP < ARRAYLENGTH )); then
+        FILENAME="${THEMES[((OP-1))]::-3}"
+        FILENAME_SPACE="${FILENAME//-/ }"
         echo "Theme: ${FILENAME_SPACE^}"
-        SET_THEME="${THEMES[(($OP-1))]}"
+        SET_THEME="${THEMES[((OP-1))]}"
         set_gogh "${SET_THEME}"
         exit 1
     else


### PR DESCRIPTION
* Multiple themes can be installed in one instance - theme selection numbers should be seperated by space as before
* Respective theme name is now properly shown instead of the last assignment of `FILENAME_SPACE` viz. the Last theme's name

_Tested on KDE Neon with GNOME Terminal, works._