### PR TITLE
Fixing the problem with the installation of the Solarized Dark theme

### DIFF
--- a/content/themes.md
+++ b/content/themes.md
@@ -218,7 +218,7 @@ $ wget -O xt  http://git.io/v3DBO && chmod +x xt && ./xt && rm xt
 ## Solarized Dark
 
 ```bash
-$ wget -O xt  http://git.io/v3DBQ && chmod +x xt && ./xt && rm xt
+$ wget -O xt  http://git.io/v5f6B && chmod +x xt && ./xt && rm xt
 ```
 
 ![Solarized Dark](https://raw.githubusercontent.com/Mayccoll/Gogh/master/images/themes/solarized.dark.png)

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -417,7 +417,7 @@
 <li class="mix dark bg-blue">
 <h3> Solarized Dark </h3>
 <div class="code-wrap">
-<pre><code class=language-bash id="solarized-dark">wget -O xt http://git.io/v3DBQ && chmod +x xt && ./xt && rm xt</code></pre>
+<pre><code class=language-bash id="solarized-dark">wget -O xt http://git.io/v5f6B && chmod +x xt && ./xt && rm xt</code></pre>
 <span class="btn-copy" data-clipboard-target="#solarized-dark">
     <img class="clippy" src="./img/clippy.svg" alt="Copy to clipboard">
 </span>
@@ -559,7 +559,7 @@
 credits:
 <a target=_blank href="https://mixitup.kunkalabs.com/"> Mixitup </a>
 - <a target=_blank href="http://codyhouse.co/gem/content-filter/"> Codyhouse </a>
-- <a target=_blank href="https://clipboardjs.com/"> Clipboardjs </a> 
+- <a target=_blank href="https://clipboardjs.com/"> Clipboardjs </a>
 put it all together : <a href=http://lanet.co>Lanet.co</a>
 </footer>
     <script src=./components/jquery/jquery.min.js></script>

--- a/test/test.sh
+++ b/test/test.sh
@@ -105,7 +105,7 @@ wget -O xt  http://git.io/v3DBO && chmod +x xt && ./xt && rm xt
 color
 wget -O xt  http://git.io/v3DBP && chmod +x xt && ./xt && rm xt
 color
-wget -O xt  http://git.io/v3DBQ && chmod +x xt && ./xt && rm xt
+wget -O xt  http://git.io/v5f6B && chmod +x xt && ./xt && rm xt
 color
 wget -O xt  http://git.io/v3DBT && chmod +x xt && ./xt && rm xt
 color


### PR DESCRIPTION
The previously shorten URL that was used to install the Solarized Dark theme was not working because was pointing to a non existent file. The new shorten URL is pointing to the existent theme file into the repository.