### PR TITLE
Fixed $TERMINAL containing name of shell

### DIFF
--- a/gogh.sh
+++ b/gogh.sh
@@ -168,7 +168,7 @@ set_gogh () {
     string_r="${string%???}"
     string_s=${string_r//\./_}
     result="${string_s^}"
-    export {PROFILE_NAME,PROFILE_SLUG}=$result && wget -O gogh https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/$1 && chmod +x gogh && ./gogh && rm gogh
+    export {PROFILE_NAME,PROFILE_SLUG}=$result && source <(wget -O - https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/$1)
 }
 
 ### Get length of an array


### PR DESCRIPTION
Resolves issue #102 by calling the respective theme via `source`.