### PR TITLE
Added a variant of "One Half Dark"

### DIFF
--- a/themes/one-half-black.sh
+++ b/themes/one-half-black.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This is an adaptation of the "One Half Dark" color scheme published by
+# Son A. Pham under the MIT license: https://github.com/sonph/onehalf
 
 # ====================CONFIG THIS =============================== #
 COLOR_01="#282c34"           # HOST
@@ -19,10 +21,10 @@ COLOR_14="#c678dd"           #
 COLOR_15="#56b6c2"           #
 COLOR_16="#dcdfe4"           #
 
-BACKGROUND_COLOR="#282c34"   # Background Color
+BACKGROUND_COLOR="#000000"   # Background Color
 FOREGROUND_COLOR="#dcdfe4"   # Text
 CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor
-PROFILE_NAME="One Half Dark"
+PROFILE_NAME="One Half Black"
 # =============================================
 
 

--- a/themes/one-half-dark.sh
+++ b/themes/one-half-dark.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# ====================CONFIG THIS =============================== #
+COLOR_01="#282c34"           # HOST
+COLOR_02="#e06c75"           # SYNTAX_STRING
+COLOR_03="#98c379"           # COMMAND
+COLOR_04="#e5c07b"           # COMMAND_COLOR2
+COLOR_05="#61afef"           # PATH
+COLOR_06="#c678dd"           # SYNTAX_VAR
+COLOR_07="#56b6c2"           # PROMP
+COLOR_08="#dcdfe4"           #
+
+COLOR_09="#282c34"           #
+COLOR_10="#e06c75"           # COMMAND_ERROR
+COLOR_11="#98c379"           # EXEC
+COLOR_12="#e5c07b"           #
+COLOR_13="#61afef"           # FOLDER
+COLOR_14="#c678dd"           #
+COLOR_15="#56b6c2"           #
+COLOR_16="#dcdfe4"           #
+
+BACKGROUND_COLOR="#282c34"   # Background Color
+FOREGROUND_COLOR="#dcdfe4"   # Text
+CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor
+PROFILE_NAME="One Half Dark"
+# =============================================
+
+
+
+
+
+
+
+# =============================================================== #
+# | Apply Colors
+# ===============================================================|#
+function gogh_colors () {
+    echo ""
+    echo -e "\e[0;30m█████\\e[0m\e[0;31m█████\\e[0m\e[0;32m█████\\e[0m\e[0;33m█████\\e[0m\e[0;34m█████\\e[0m\e[0;35m█████\\e[0m\e[0;36m█████\\e[0m\e[0;37m█████\\e[0m"
+    echo -e "\e[0m\e[1;30m█████\\e[0m\e[1;31m█████\\e[0m\e[1;32m█████\\e[0m\e[1;33m█████\\e[0m\e[1;34m█████\\e[0m\e[1;35m█████\\e[0m\e[1;36m█████\\e[0m\e[1;37m█████\\e[0m"
+    echo ""
+}
+
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PARENT_PATH="$(dirname "$SCRIPT_PATH")"
+
+if [ -e $PARENT_PATH"/apply-colors.sh" ]
+then
+gogh_colors
+source $PARENT_PATH"/apply-colors.sh"
+
+else
+gogh_colors
+source <(wget  -O - https://raw.githubusercontent.com/Mayccoll/Gogh/master/apply-colors.sh)
+fi


### PR DESCRIPTION
As the title states, this one adds a variant of "One Half Dark" theme from [here](https://github.com/sonph/onehalf).

An adaptation was needed as the original theme uses the same colour for both `COLOR_01` and `BACKGROUND_COLOR`, making many applications (e.g. `htop`) illegible. Here the background was set to pure black (thus the naming of the variant: "One Half Black").

![onehalfblack](https://user-images.githubusercontent.com/1607520/31764710-49c1a62a-b4c2-11e7-9f83-73bda34e241e.png)

Let me know if something still needs to be done for this pull request to be accepted.