### PR TITLE
Minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,24 +60,24 @@ If you want to create your own color scheme or contribute to the project. [Here.
 ## Credits:
 
 - [4bit](http://ciembor.github.io/4bit/)
-- Flat Theme - inspired by https://dribbble.com/shots/1021755-Flat-UI-Terminal-Theme
-- https://github.com/zenorocha/dracula-theme
-- http://ethanschoonover.com/solarized
-- Monokai
-- [Elementary Os](https://elementary.io/)
-- https://github.com/chalk/chalk
-- [Snazzy](https://github.com/sindresorhus/hyper-snazzy)
-- [Hemisu color themes](https://noahfrederick.com/log/hemisu-for-os-x-terminal/) by Noah Frederick.
-- [Peppermint color theme](https://noahfrederick.com/log/lion-terminal-theme-peppermint/) by Noah Frederick.
-- [Ocean theme](https://github.com/fabianperez/ocean-dark-iterm) by [Fabian Perez](https://github.com/fabianperez).
-- [SMYCK color theme](http://color.smyck.org/) originally created by John-Paul Bader ([hukl](https://github.com/hukl)).
-- [Mitchel van Eijgen](https://gist.github.com/mvaneijgen/4c56701215847dd5ddcf) and [Liu Xinan](https://gist.github.com/xinan/ca2b82fef6aaa0d1e099).
-- [Tomorrow color theme set](https://github.com/chriskempson/tomorrow-theme) by [Chris Kempson](https://github.com/chriskempson).
-- [One Dark & Light theme set](https://github.com/nathanbuchar/one-dark-terminal) by [Nathan Buchar](https://github.com/nathanbuchar).
-- [Terminal Sexy](https://terminal.sexy)
-- [Gruvbox](https://github.com/morhetz/gruvbox)
-- [Tilix](https://github.com/storm119/Tilix-Themes)
+- [Chalk](https://github.com/chalk/chalk) by [Sindre Sorhus](https://github.com/sindresorhus)
+- [Dracula](https://github.com/dracula/dracula-theme) by [Zeno Rocha](https://github.com/zenorocha)
+- [Elementary OS](https://elementary.io/)
+- [Flat UI Terminal Theme](https://dribbble.com/shots/1021755-Flat-UI-Terminal-Theme)
+- [Gruvbox](https://github.com/morhetz/gruvbox) by [Pavel Pertsev](https://github.com/morhetz)
+- [Hemisu](https://noahfrederick.com/log/hemisu-for-os-x-terminal/) by [Noah Frederick](https://github.com/noahfrederick)
+- Material theme by [Mitchel van Eijgen](https://gist.github.com/mvaneijgen/4c56701215847dd5ddcf) and [Liu Xinan](https://gist.github.com/xinan/ca2b82fef6aaa0d1e099)
+- [Monokai](https://web.archive.org/web/20161117102850/http://www.monokai.nl/blog/2006/07/15/textmate-color-theme) by [Wimer Hazenberg](https://github.com/monokai)
+- [Ocean](https://github.com/fabianperez/ocean-dark-iterm) by [Fabian Perez](https://github.com/fabianperez)
+- [One Dark & Light theme set](https://github.com/nathanbuchar/one-dark-terminal) by [Nathan Buchar](https://github.com/nathanbuchar)
+- [Peppermint](https://noahfrederick.com/log/lion-terminal-theme-peppermint/) by [Noah Frederick](https://github.com/noahfrederick)
+- [SMYCK](http://color.smyck.org/) by [John-Paul Bader](https://github.com/hukl)
+- [Snazzy](https://github.com/sindresorhus/hyper-snazzy) by [Sindre Sorhus](https://github.com/sindresorhus)
+- [Solarized](http://ethanschoonover.com/solarized) by [Ethan Schoonover](https://github.com/altercation)
 - [Srcery](https://github.com/roosta/vim-srcery) by [Daniel Berg](https://github.com/roosta)
+- [Terminal Sexy](https://terminal.sexy) by [George Czabania](https://github.com/stayradiated)
+- [Tilix](https://github.com/storm119/Tilix-Themes)
+- [Tomorrow color theme set](https://github.com/chriskempson/tomorrow-theme) by [Chris Kempson](https://github.com/chriskempson)
 
 
 <br/>
@@ -94,7 +94,7 @@ If you want to create your own color scheme or contribute to the project. [Here.
 
 ## Author
 
-- Miguel D. Quintero - [Lanet.co](http:lanet.co)
+- Miguel D. Quintero - [Lanet.co](http://lanet.co)
 
 
 

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -25,7 +25,7 @@ convertRGBtoMac () {
     R=$(echo "${R} / 255" | bc -l)
     G=$(echo "${G} / 255" | bc -l)
     B=$(echo "${B} / 255" | bc -l)
-    echo $R $G $B
+    echo "$R" "$G" "$B"
 }
 
 convertNameAndRGBtoITerm() {
@@ -80,19 +80,19 @@ set_theme() {
 # | Check for the terminal name (depening on os)
 # | ===========================================
 OS=$(uname)
-if [ $OS = "Darwin" ]; then
+if [ "$OS" = "Darwin" ]; then
     # |
     # | Check for the terminal name and decide how to apply
     # | ===========================================
     TERMINAL=$TERM_PROGRAM
-else  
-    TERMINAL=$(ps -p $(ps -p $(ps -p $$ -o ppid=) -o ppid=) -o args=)
+else
+    TERMINAL="$(ps -p $(ps -p $(ps -p $$ -o ppid=) -o ppid=) -o args=)"
 fi
 
 # |
 # | Apply color scheme to terminal
 # | ===========================================
-if [[ $TERMINAL =~ "guake" ]]; then
+if [[ "$TERMINAL" =~ "guake" ]]; then
     # |
     # | Applying values if string contains guake
     # | =============================================
@@ -103,38 +103,38 @@ if [[ $TERMINAL =~ "guake" ]]; then
     gconftool-2 -s -t string /apps/guake/style/font/palette "${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}"
     gconftool-2 -s -t string /apps/guake/style/font/palette_name "${PROFILE_NAME}"
 
-elif [ $TERMINAL = "iTerm.app" ]; then
+elif [ "$TERMINAL" = "iTerm.app" ]; then
     # |
     # | Applying values on iTerm2
     # | ===========================================
-    BACKGROUND_COLOR=$(convertNameAndRGBtoITerm "Background Color" $BACKGROUND_COLOR)
-    FOREGROUND_COLOR=$(convertNameAndRGBtoITerm "Foreground Color" $FOREGROUND_COLOR)
-    COLOR_01=$(convertNameAndRGBtoITerm "Ansi 0 Color" $COLOR_01)
-    COLOR_02=$(convertNameAndRGBtoITerm "Ansi 1 Color" $COLOR_02)
-    COLOR_03=$(convertNameAndRGBtoITerm "Ansi 2 Color" $COLOR_03)
-    COLOR_04=$(convertNameAndRGBtoITerm "Ansi 3 Color" $COLOR_04)
-    COLOR_05=$(convertNameAndRGBtoITerm "Ansi 4 Color" $COLOR_05)
-    COLOR_06=$(convertNameAndRGBtoITerm "Ansi 5 Color" $COLOR_06)
-    COLOR_07=$(convertNameAndRGBtoITerm "Ansi 6 Color" $COLOR_07)
-    COLOR_08=$(convertNameAndRGBtoITerm "Ansi 7 Color" $COLOR_08)
-    COLOR_09=$(convertNameAndRGBtoITerm "Ansi 8 Color" $COLOR_09)
-    COLOR_10=$(convertNameAndRGBtoITerm "Ansi 9 Color" $COLOR_10)
-    COLOR_11=$(convertNameAndRGBtoITerm "Ansi 10 Color" $COLOR_11)
-    COLOR_12=$(convertNameAndRGBtoITerm "Ansi 11 Color" $COLOR_12)
-    COLOR_13=$(convertNameAndRGBtoITerm "Ansi 12 Color" $COLOR_13)
-    COLOR_14=$(convertNameAndRGBtoITerm "Ansi 13 Color" $COLOR_14)
-    COLOR_15=$(convertNameAndRGBtoITerm "Ansi 14 Color" $COLOR_15)
-    COLOR_16=$(convertNameAndRGBtoITerm "Ansi 15 Color" $COLOR_16)
+    BACKGROUND_COLOR=$(convertNameAndRGBtoITerm "Background Color" "$BACKGROUND_COLOR")
+    FOREGROUND_COLOR=$(convertNameAndRGBtoITerm "Foreground Color" "$FOREGROUND_COLOR")
+    COLOR_01=$(convertNameAndRGBtoITerm "Ansi 0 Color" "$COLOR_01")
+    COLOR_02=$(convertNameAndRGBtoITerm "Ansi 1 Color" "$COLOR_02")
+    COLOR_03=$(convertNameAndRGBtoITerm "Ansi 2 Color" "$COLOR_03")
+    COLOR_04=$(convertNameAndRGBtoITerm "Ansi 3 Color" "$COLOR_04")
+    COLOR_05=$(convertNameAndRGBtoITerm "Ansi 4 Color" "$COLOR_05")
+    COLOR_06=$(convertNameAndRGBtoITerm "Ansi 5 Color" "$COLOR_06")
+    COLOR_07=$(convertNameAndRGBtoITerm "Ansi 6 Color" "$COLOR_07")
+    COLOR_08=$(convertNameAndRGBtoITerm "Ansi 7 Color" "$COLOR_08")
+    COLOR_09=$(convertNameAndRGBtoITerm "Ansi 8 Color" "$COLOR_09")
+    COLOR_10=$(convertNameAndRGBtoITerm "Ansi 9 Color" "$COLOR_10")
+    COLOR_11=$(convertNameAndRGBtoITerm "Ansi 10 Color" "$COLOR_11")
+    COLOR_12=$(convertNameAndRGBtoITerm "Ansi 11 Color" "$COLOR_12")
+    COLOR_13=$(convertNameAndRGBtoITerm "Ansi 12 Color" "$COLOR_13")
+    COLOR_14=$(convertNameAndRGBtoITerm "Ansi 13 Color" "$COLOR_14")
+    COLOR_15=$(convertNameAndRGBtoITerm "Ansi 14 Color" "$COLOR_15")
+    COLOR_16=$(convertNameAndRGBtoITerm "Ansi 15 Color" "$COLOR_16")
 
     # Assemble color scheme file contents
     ITERMCOLORS='<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict>'${BACKGROUND_COLOR}${FOREGROUND_COLOR}${COLOR_01}${COLOR_02}${COLOR_03}${COLOR_04}${COLOR_05}${COLOR_06}${COLOR_07}${COLOR_08}${COLOR_09}${COLOR_10}${COLOR_11}${COLOR_12}${COLOR_13}${COLOR_14}${COLOR_15}'</dict></plist>'
-    
+
     # Dump iTerm color scheme to file and import it by opening it
-    echo $ITERMCOLORS > "${PROFILE_NAME}.itermcolors"
+    echo "$ITERMCOLORS" > "${PROFILE_NAME}.itermcolors"
     open "${PROFILE_NAME}.itermcolors"
     rm "${PROFILE_NAME}.itermcolors"
 
-elif [ $TERMINAL = "pantheon-terminal" ]; then
+elif [ "$TERMINAL" = "pantheon-terminal" ]; then
     # |
     # | Applying values on pantheon-terminal
     # | ===========================================
@@ -143,22 +143,22 @@ elif [ $TERMINAL = "pantheon-terminal" ]; then
     gsettings set org.pantheon.terminal.settings cursor-color "${CURSOR_COLOR}"
     gsettings set org.pantheon.terminal.settings palette "${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}"
 
-elif [ $TERMINAL = "mate-terminal" ]; then
+elif [ "$TERMINAL" = "mate-terminal" ]; then
     # |
     # | Applying values on pantheon-terminal
     # | ===========================================
 
     [[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Default"
-    [[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG=`uuidgen`
+    [[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG=$(uuidgen)
     [[ -z "$DCONF" ]] && DCONF=dconf
 
     BASE_DIR=/org/mate/terminal
     PROFILE_DIR="$BASE_DIR/profiles"
 
-    if [[ -n "`$DCONF read $BASE_DIR/global/default-profile`" ]]; then
-        DEFAULT_SLUG=`$DCONF read $BASE_DIR/global/default-profile | tr -d \'`
+    if [[ -n "$($DCONF read $BASE_DIR/global/default-profile)" ]]; then
+        DEFAULT_SLUG=$($DCONF read $BASE_DIR/global/default-profile | tr -d \')
     else
-        DEFAULT_SLUG=`$DCONF list $PROFILE_DIR/ | head -n1 | tr -d \/`
+        DEFAULT_SLUG=$($DCONF list $PROFILE_DIR/ | head -n1 | tr -d \/)
     fi
 
     DEFAULT_KEY="$PROFILE_DIR/$DEFAULT_SLUG"
@@ -168,10 +168,10 @@ elif [ $TERMINAL = "mate-terminal" ]; then
     dconf dump "$DEFAULT_KEY/" | dconf load "$PROFILE_KEY/"
 
     # add new copy to list of profiles
-    dlist_append $PROFILE_DIR/list "$PROFILE_SLUG"
+    dlist_append "$PROFILE_DIR/list" "$PROFILE_SLUG"
 
     # add new copy to global list of profiles
-    dlist_append $BASE_DIR/global/profile-list "$PROFILE_SLUG"
+    dlist_append "$BASE_DIR/global/profile-list" "$PROFILE_SLUG"
 
     set_theme
     dset palette "'${COLOR_01}:${COLOR_02}:${COLOR_03}:${COLOR_04}:${COLOR_05}:${COLOR_06}:${COLOR_07}:${COLOR_08}:${COLOR_09}:${COLOR_10}:${COLOR_11}:${COLOR_12}:${COLOR_13}:${COLOR_14}:${COLOR_15}:${COLOR_16}'"
@@ -183,24 +183,24 @@ else
     # |
     # | Applying values on gnome-terminal
     # | ===========================================
-    BACKGROUND_COLOR=$(gnome_color $BACKGROUND_COLOR)
-    FOREGROUND_COLOR=$(gnome_color $FOREGROUND_COLOR)
-    COLOR_01=$(gnome_color $COLOR_01)
-    COLOR_02=$(gnome_color $COLOR_02)
-    COLOR_03=$(gnome_color $COLOR_03)
-    COLOR_04=$(gnome_color $COLOR_04)
-    COLOR_05=$(gnome_color $COLOR_05)
-    COLOR_06=$(gnome_color $COLOR_06)
-    COLOR_07=$(gnome_color $COLOR_07)
-    COLOR_08=$(gnome_color $COLOR_08)
-    COLOR_09=$(gnome_color $COLOR_09)
-    COLOR_10=$(gnome_color $COLOR_10)
-    COLOR_11=$(gnome_color $COLOR_11)
-    COLOR_12=$(gnome_color $COLOR_12)
-    COLOR_13=$(gnome_color $COLOR_13)
-    COLOR_14=$(gnome_color $COLOR_14)
-    COLOR_15=$(gnome_color $COLOR_15)
-    COLOR_16=$(gnome_color $COLOR_16)
+    BACKGROUND_COLOR=$(gnome_color "$BACKGROUND_COLOR")
+    FOREGROUND_COLOR=$(gnome_color "$FOREGROUND_COLOR")
+    COLOR_01=$(gnome_color "$COLOR_01")
+    COLOR_02=$(gnome_color "$COLOR_02")
+    COLOR_03=$(gnome_color "$COLOR_03")
+    COLOR_04=$(gnome_color "$COLOR_04")
+    COLOR_05=$(gnome_color "$COLOR_05")
+    COLOR_06=$(gnome_color "$COLOR_06")
+    COLOR_07=$(gnome_color "$COLOR_07")
+    COLOR_08=$(gnome_color "$COLOR_08")
+    COLOR_09=$(gnome_color "$COLOR_09")
+    COLOR_10=$(gnome_color "$COLOR_10")
+    COLOR_11=$(gnome_color "$COLOR_11")
+    COLOR_12=$(gnome_color "$COLOR_12")
+    COLOR_13=$(gnome_color "$COLOR_13")
+    COLOR_14=$(gnome_color "$COLOR_14")
+    COLOR_15=$(gnome_color "$COLOR_15")
+    COLOR_16=$(gnome_color "$COLOR_16")
 
     # |
     # | Apply Variables
@@ -216,15 +216,15 @@ else
     if which "$DCONF" > /dev/null 2>&1; then
         [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
 
-        if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
+        if [[ -n "$($DCONF list $BASE_KEY_NEW/)" ]]; then
             if which "$UUIDGEN" > /dev/null 2>&1; then
-                PROFILE_SLUG=`uuidgen`
+                PROFILE_SLUG=$(uuidgen)
             fi
 
-            if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
-                DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+            if [[ -n "$($DCONF read $BASE_KEY_NEW/default)" ]]; then
+                DEFAULT_SLUG=$($DCONF read $BASE_KEY_NEW/default | tr -d \')
             else
-                DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+                DEFAULT_SLUG=$($DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/)
             fi
 
             DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
@@ -234,7 +234,7 @@ else
             $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
 
             # add new copy to list of profiles
-            dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+            dlist_append "$BASE_KEY_NEW/list" "$PROFILE_SLUG"
 
             # update profile values with theme options
 	    set_theme
@@ -286,7 +286,7 @@ else
             } | head -c-1 | tr "\n" ,
         )"
 
-        "$GCONFTOOL" --set --type list --list-type $type "$key" "[$entries]"
+        "$GCONFTOOL" --set --type list --list-type "$type" "$key" "[$entries]"
     }
 
     # Append the Base16 profile to the profile list

--- a/gogh.sh
+++ b/gogh.sh
@@ -167,8 +167,15 @@ declare -a THEMES=(
 )
 
 capitalize (){
-    RES=""
-    for str in $1; do Str=`echo "${str:0:1}" | tr "[:lower:]" "[:upper:]"`"${str:1} "; RES="${RES}${Str}"; done
+    local RES=""
+    local string=$1
+
+    for char in $string
+    do
+        str=$(echo "${char:0:1}" | tr "[:lower:]" "[:upper:]")"${char:1} "
+        RES="${RES}${str}"
+    done
+
     echo "${RES}"
 }
 
@@ -183,20 +190,20 @@ set_gogh () {
     string=$1
     string_r="${string%???}"
     string_s=${string_r//\./_}
-	result=$(capitalize "${string_s}")
-	url="https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/$1"
+    result=$(capitalize "${string_s}")
+    url="https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/$1"
 
-	if [ $(uname) = "Darwin" ]; then
-		# OSX ships with curl
-		# Note: sourcing directly from curl does not work
-        export {PROFILE_NAME,PROFILE_SLUG}=$result && curlsource "${url}"
-	else
-        export {PROFILE_NAME,PROFILE_SLUG}=$result && source <(wget -O - "${url}")
+    if [ "$(uname)" = "Darwin" ]; then
+        # OSX ships with curl
+        # Note: sourcing directly from curl does not work
+        export {PROFILE_NAME,PROFILE_SLUG}="$result" && curlsource "${url}"
+    else
+        export {PROFILE_NAME,PROFILE_SLUG}="$result" && source <(wget -O - "${url}")
     fi
 }
 
 remove_file_extension (){
-	echo "${1%.*}"
+    echo "${1%.*}"
 }
 
 ### Get length of an array
@@ -243,9 +250,9 @@ for OP in "${OPTION[@]}"; do
 
     if [[ OP -le ARRAYLENGTH && OP -gt 0 ]]; then
 
-		FILENAME=$(remove_file_extension "${THEMES[((OP-1))]}")
+        FILENAME=$(remove_file_extension "${THEMES[((OP-1))]}")
         FILENAME_SPACE="${FILENAME//-/ }"
-		echo "Theme: $(capitalize "${FILENAME_SPACE}")"
+        echo "Theme: $(capitalize "${FILENAME_SPACE}")"
         SET_THEME="${THEMES[((OP-1))]}"
         set_gogh "${SET_THEME}"
     else

--- a/themes/_base.sh
+++ b/themes/_base.sh
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
 
 # ====================CONFIG THIS =============================== #
-COLOR_01="#44475a"           # HOST
-COLOR_02="#ff5555"           # SYNTAX_STRING
-COLOR_03="#50fa7b"           # COMMAND
-COLOR_04="#ffb86c"           # COMMAND_COLOR2
-COLOR_05="#8be9fd"           # PATH
-COLOR_06="#bd93f9"           # SYNTAX_VAR
-COLOR_07="#ff79c6"           # PROMP
-COLOR_08="#94A3A5"           #
+COLOR_01="#44475a"           # Black
+COLOR_02="#ff5555"           # Red
+COLOR_03="#50fa7b"           # Green
+COLOR_04="#ffb86c"           # Yellow
+COLOR_05="#8be9fd"           # Blue
+COLOR_06="#bd93f9"           # Cyan
+COLOR_07="#ff79c6"           # Magenta
+COLOR_08="#94A3A5"           # Light gray
 
-COLOR_09="#000000"           #
-COLOR_10="#ff5555"           # COMMAND_ERROR
-COLOR_11="#50fa7b"           # EXEC
-COLOR_12="#ffb86c"           #
-COLOR_13="#8be9fd"           # FOLDER
-COLOR_14="#bd93f9"           #
-COLOR_15="#ff79c6"           #
-COLOR_16="#ffffff"           #
+COLOR_09="#000000"           # Dark gray
+COLOR_10="#ff5555"           # Light Red
+COLOR_11="#50fa7b"           # Light Green
+COLOR_12="#ffb86c"           # Light Yellow
+COLOR_13="#8be9fd"           # Light Blue
+COLOR_14="#bd93f9"           # Light Cyan
+COLOR_15="#ff79c6"           # Light Magenta
+COLOR_16="#ffffff"           # White
 
 BACKGROUND_COLOR="#282a36"   # Background Color
-FOREGROUND_COLOR="#94A3A5"   # Text
-CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor
+FOREGROUND_COLOR="#94A3A5"   # Foreground Color (text)
+CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor color
 PROFILE_NAME="_base"
 # =============================================
 
@@ -48,16 +48,15 @@ function curlsource() {
     rm -f "$f"
 }
 
-SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PARENT_PATH="$(dirname "$SCRIPT_PATH")"
+
+gogh_colors
 
 if [ -e $PARENT_PATH"/apply-colors.sh" ]
 then
-gogh_colors
-source $PARENT_PATH"/apply-colors.sh"
-
+    source $PARENT_PATH"/apply-colors.sh"
 else
-gogh_colors
     if [ $(uname) = "Darwin" ]; then
         # OSX ships with curl and ancient bash
         # Note: here, sourcing directly from curl does not work


### PR DESCRIPTION
- Format README.md and add links to theme authors
- Fix indentation in gogh.sh
- Modify comments to identify colors by their name rather than their
use
- shellcheck errors
  - quote variables in most places to prevent word globbing
  - use $(cmd) instead of legacy \`cmd\`