### PR TITLE
Link to Tomororw Night Theme 404'd

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
 <li class="mix dark bg-grey">
 <h3> Tomorrow Night </h3>
 <div class="code-wrap">
-<pre><code class=language-bash id="tomorrow-night">wget -O xt http://git.io/v3DRs && chmod +x xt && ./xt && rm xt</code></pre>
+<pre><code class=language-bash id="tomorrow-night">wget -O xt https://git.io/vAykz && chmod +x xt && ./xt && rm xt</code></pre>
 <span class="btn-copy" data-clipboard-target="#tomorrow-night">
     <img class="clippy" src="./img/clippy.svg" alt="Copy to clipboard">
 </span>


### PR DESCRIPTION
It tried to point to https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/tomorrow.night.sh instead of https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/tomorrow-night.sh (the filename had a dot instead of a hyphen)