### PR TITLE
Fix gruvbox.sh with light colors instead of dark colors

### DIFF
--- a/themes/gruvbox.sh
+++ b/themes/gruvbox.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
 
 # ====================CONFIG THIS =============================== #
-COLOR_01="#282828"           # HOST
+COLOR_01="#fbf1c7"           # HOST
 COLOR_02="#cc241d"           # SYNTAX_STRING
 COLOR_03="#98971a"           # COMMAND
 COLOR_04="#d79921"           # COMMAND_COLOR2
 COLOR_05="#458588"           # PATH
 COLOR_06="#b16286"           # SYNTAX_VAR
 COLOR_07="#689d6a"           # PROMP
-COLOR_08="#a89984"           #
+COLOR_08="#7c6f64"           #
 
 COLOR_09="#928374"           #
-COLOR_10="#fb4934"           # COMMAND_ERROR
-COLOR_11="#b8bb26"           # EXEC
-COLOR_12="#fabd2f"           #
-COLOR_13="#83a598"           # FOLDER
-COLOR_14="#d3869b"           #
-COLOR_15="#8ec07c"           #
-COLOR_16="#ebdbb2"           #
+COLOR_10="#9d0006"           # COMMAND_ERROR
+COLOR_11="#79740e"           # EXEC
+COLOR_12="#b57614"           #
+COLOR_13="#076678"           # FOLDER
+COLOR_14="#8f3f71"           #
+COLOR_15="#427b58"           #
+COLOR_16="#3c3836"           #
 
-BACKGROUND_COLOR="#282828"   # Background Color
-FOREGROUND_COLOR="#ebdbb2"   # Text
+BACKGROUND_COLOR="#fbf1c7"   # Background Color
+FOREGROUND_COLOR="#3c3836"   # Text
 CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor
 PROFILE_NAME="Gruvbox"
 # =============================================================== #


### PR DESCRIPTION
The `themes/gruvbox.sh` file was just a one-to-one match on the `gruvbox-dark.sh` file. I think `gruvbox.sh` was intentionally supposed to be the light version

See original README for correct color codes:
    https://github.com/morhetz/gruvbox