### PR TITLE
Allow TERMINAL to be set by environment

### DIFF
--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -102,16 +102,18 @@ set_theme() {
 # |
 # | Check for the terminal name (depening on os)
 # | ===========================================
-OS=$(uname)
-if [ "$OS" = "Darwin" ]; then
-    # |
-    # | Check for the terminal name and decide how to apply
-    # | ===========================================
-    TERMINAL=$TERM_PROGRAM
-elif [ "${OS#CYGWIN}" != "${OS}" ]; then
-    TERMINAL="mintty"
-else
-    TERMINAL="$(ps -p $(ps -p $(ps -p $$ -o ppid=) -o ppid=) -o args=)"
+if [[ -z "$TERMINAL" ]]; then
+  OS=$(uname)
+  if [ "$OS" = "Darwin" ]; then
+      # |
+      # | Check for the terminal name and decide how to apply
+      # | ===========================================
+      TERMINAL=$TERM_PROGRAM
+  elif [ "${OS#CYGWIN}" != "${OS}" ]; then
+      TERMINAL="mintty"
+  else
+      TERMINAL="$(ps -p $(ps -p $(ps -p $$ -o ppid=) -o ppid=) -o args=)"
+  fi
 fi
 
 # |


### PR DESCRIPTION
This change allow the environment to specify the value for `TERMINAL`. This is useful if you aren't running the theme script directly. For example, using a script like this:

```sh
#/usr/bin/env bash

set -e

(
  cd /tmp
  wget --quiet -O xt "https://raw.githubusercontent.com/Mayccoll/Gogh/master/themes/$1.sh"
  chmod +x xt
  TERMINAL=pantheon-terminal ./xt
  rm xt
)
```