### PR TITLE
Update command to install themes in gh-pages

### DIFF
--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -40,10 +40,10 @@
         <h2> Color Scheme for Gnome Terminal and Pantheon Terminal </h2>
         <p> Color Schemes For Ubuntu, Linux Mint, Elementary OS and all distributions that use gnome terminal or Pantheon Terminal, initially inspired by Elementary OS Luna. </p>
         <h3> Install </h3>
-        <p> Just copy and paste One line command. Each theme has his own line. </p>
+        <p> Just copy and paste One line command. </p>
 
 <div class="code-wrap">
-    <pre><code class=language-bash id="foo"> wget -O xt  http://git.io/v3D4o && chmod +x xt && ./xt && rm xt </code></pre>
+    <pre><code class=language-bash id="foo"> wget -O gogh https://git.io/vQgMr && chmod +x gogh && ./gogh && rm gogh </code></pre>
     <span class="btn-copy" data-clipboard-target="#foo">
         <img class="clippy" src="./img/clippy.svg" alt="Copy to clipboard">
     </span>


### PR DESCRIPTION
I noticed that on the webpage http://mayccoll.github.io/Gogh/ the command for installing themes only installs Freya theme. Here is a PR to replace it with the command from GitHub README, which allows to chose from the full list of themes.