### PR TITLE
Add uuid-runtime on pre-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Color Schemes For Ubuntu, Linux Mint, Elementary OS and all distributions that u
 ## Pre-Install
 
 ```bash
-  $ sudo apt-get install dconf-cli
+  $ sudo apt-get install dconf-cli uuid-runtime
 ```
 
 ## [Install](https://github.com/Mayccoll/Gogh/blob/master/content/install.md)


### PR DESCRIPTION
The installer script create profile with id as the theme name. uuid-runtime package is needed to generate random id for profile, so terminal can read the new profile.