### PR TITLE
Fix command statement

### DIFF
--- a/gh-pages/index.src.html
+++ b/gh-pages/index.src.html
@@ -64,7 +64,7 @@
 
         <div class="code-wrap">
             <p>Linux</p>
-            <pre><code class=language-bash id="code-linux"> $  bash -c  "$(wget -qO- https://git.io/vQgMr)" </code></pre>
+            <pre><code class=language-bash id="code-linux"> bash -c  "$(wget -qO- https://git.io/vQgMr)" </code></pre>
             <span class="btn-copy" data-clipboard-target="#code-linux">
                 <img class="clippy" src="./img/clippy.svg" alt="Copy to clipboard">
             </span>
@@ -72,7 +72,7 @@
 
         <div class="code-wrap">
             <p>Mac</p>
-            <pre><code class=language-bash id="code-mac"> $  bash -c  "$(curl -sLo- https://git.io/vQgMr)" </code></pre>
+            <pre><code class=language-bash id="code-mac"> bash -c  "$(curl -sLo- https://git.io/vQgMr)" </code></pre>
             <span class="btn-copy" data-clipboard-target="#code-mac">
                 <img class="clippy" src="./img/clippy.svg" alt="Copy to clipboard">
             </span>


### PR DESCRIPTION
The command with '$' prompt at the start throws an error while copying and pasting the command into the terminal.