### PR TITLE
Insert missing # in cursor colors

### DIFF
--- a/themes/ir-black.sh
+++ b/themes/ir-black.sh
@@ -21,7 +21,7 @@ export COLOR_16="#ffffff"           #
 
 export BACKGROUND_COLOR="#000000"   # Background Color
 export FOREGROUND_COLOR="#eeeeee"   # Text
-export CURSOR_COLOR="ffa560"        # Cursor
+export CURSOR_COLOR="#ffa560"        # Cursor
 export PROFILE_NAME="Ir Black"
 # =============================================
 

--- a/themes/synthwave.sh
+++ b/themes/synthwave.sh
@@ -21,7 +21,7 @@ export COLOR_16="#ffffff"           # White
 
 export BACKGROUND_COLOR="#262335"   # Background Color
 export FOREGROUND_COLOR="#ffffff"   # Foreground Color (text)
-export CURSOR_COLOR="03edf9" # Cursor color
+export CURSOR_COLOR="#03edf9" # Cursor color
 export PROFILE_NAME="SynthWave"
 # =============================================================== #
 


### PR DESCRIPTION
There were two themes whose cursor color had a missing "#" prefix:

- ir-black
- synthwave

I discovered these issues while generating a json list with all themes for use in the Windows Terminal Config ([result](https://gist.github.com/rapgru/09b449285231d18f4e4536c5f48fc927)). This is unrelated to the problem fixed in this PR, but maybe you could somehow use this gist or place a link in the README.