### PR TITLE
Ubuntu 20.04 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Color Schemes For Ubuntu, Linux Mint, Elementary OS and all distributions that u
   $ sudo apt-get install dconf-cli uuid-runtime
 ```
 
-Additional for Ubuntu 20.04:
+Additionally for Ubuntu 20.04:
 
 ```bash
   $ sudo apt-get install gconf2

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Color Schemes For Ubuntu, Linux Mint, Elementary OS and all distributions that u
   $ sudo apt-get install dconf-cli uuid-runtime
 ```
 
+Additional for Ubuntu 20.04:
+
+```bash
+  $ sudo apt-get install gconf2
+```
+
 You can now install in interactive mode (easy) or non-interactive mode (ideal for scripting)
 
 ## [Install (interactive mode)](https://github.com/Mayccoll/Gogh/blob/master/content/install.md)


### PR DESCRIPTION
Had troubles running on a clean Ubuntu 20.04 install, fixed them installing gconf2

The errors were:
$HOME/src/gogh/gogh/apply-colors.sh: line 674: read: `/apps/gnome-terminal/profiles/default_profile': not a valid identifier
$HOME/src/gogh/gogh/apply-colors.sh: line 415: --get: command not found

Replace $HOME with the local home path, it wasn't displayed as a variable, hope it helps.