### PR TITLE
Update Google Light and Dark theme

### DIFF
--- a/themes/google-dark.sh
+++ b/themes/google-dark.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
 
 # ====================CONFIG THIS =============================== #
-export COLOR_01="#1D1F21"           # Black
-export COLOR_02="#CC342B"           # Red
-export COLOR_03="#198844"           # Green
-export COLOR_04="#FBA922"           # Yellow
-export COLOR_05="#3971ED"           # Blue
-export COLOR_06="#A36AC7"           # Cyan
-export COLOR_07="#3971ED"           # Magenta
-export COLOR_08="#C5C8C6"           # Light gray
+export COLOR_01="#000000"           # Black
+export COLOR_02="#EA4335"           # Red
+export COLOR_03="#34A853"           # Green
+export COLOR_04="#FBBC05"           # Yellow
+export COLOR_05="#4285F4"           # Blue
+export COLOR_06="#A142F4"           # Cyan
+export COLOR_07="#24C1E0"           # Purple
+export COLOR_08="#EEEEEE"           # Light gray
 
-export COLOR_09="#969896"           # Dark gray
-export COLOR_10="#CC342B"           # Light Red
-export COLOR_11="#198844"           # Light Green
-export COLOR_12="#FBA922"           # Light Yellow
-export COLOR_13="#3971ED"           # Light Blue
-export COLOR_14="#A36AC7"           # Light Cyan
-export COLOR_15="#3971ED"           # Light Magenta
+export COLOR_09="#656565"           # Dark gray
+export COLOR_10="#EA4335"           # Bright Red
+export COLOR_11="#34A853"           # Bright Green
+export COLOR_12="#FBBC05"           # Bright Yellow
+export COLOR_13="#4285F4"           # Bright Blue
+export COLOR_14="#A142F4"           # Bright Cyan
+export COLOR_15="#24C1E0"           # Bright Purple
 export COLOR_16="#FFFFFF"           # White
 
-export BACKGROUND_COLOR="#1D1F21"   # Background Color
-export FOREGROUND_COLOR="#B4B7B4"   # Foreground Color (text)
+export BACKGROUND_COLOR="#000000"   # Background Color
+export FOREGROUND_COLOR="#EEEEEE"   # Foreground Color (text)
 export CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor color
-export PROFILE_NAME="base16: Google (dark)"
+export PROFILE_NAME="Google Dark"
 # =============================================
 
 

--- a/themes/google-light.sh
+++ b/themes/google-light.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
 
 # ====================CONFIG THIS =============================== #
-export COLOR_01="#FFFFFF"           # Black
-export COLOR_02="#CC342B"           # Red
-export COLOR_03="#198844"           # Green
-export COLOR_04="#FBA921"           # Yellow
-export COLOR_05="#3870ED"           # Blue
-export COLOR_06="#A26AC7"           # Cyan
-export COLOR_07="#3870ED"           # Magenta
-export COLOR_08="#373B41"           # Light gray
+export COLOR_01="#000000"           # Black
+export COLOR_02="#EA4335"           # Red
+export COLOR_03="#34A853"           # Green
+export COLOR_04="#FBBC05"           # Yellow
+export COLOR_05="#4285F4"           # Blue
+export COLOR_06="#A142F4"           # Cyan
+export COLOR_07="#24C1E0"           # Purple
+export COLOR_08="#EEEEEE"           # Light gray
 
-export COLOR_09="#C5C8C6"           # Dark gray
-export COLOR_10="#CC342B"           # Light Red
-export COLOR_11="#198844"           # Light Green
-export COLOR_12="#FBA921"           # Light Yellow
-export COLOR_13="#3870ED"           # Light Blue
-export COLOR_14="#A26AC7"           # Light Cyan
-export COLOR_15="#3870ED"           # Light Magenta
-export COLOR_16="#1D1F21"           # White
+export COLOR_09="#656565"           # Dark gray
+export COLOR_10="#EA4335"           # Bright Red
+export COLOR_11="#34A853"           # Bright Green
+export COLOR_12="#FBBC05"           # Bright Yellow
+export COLOR_13="#4285F4"           # Bright Blue
+export COLOR_14="#A142F4"           # Bright Cyan
+export COLOR_15="#24C1E0"           # Bright Purple
+export COLOR_16="#FFFFFF"           # White
 
 export BACKGROUND_COLOR="#FFFFFF"   # Background Color
-export FOREGROUND_COLOR="#373B41"   # Foreground Color (text)
+export FOREGROUND_COLOR="#656565"   # Foreground Color (text)
 export CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor color
-export PROFILE_NAME="base16: Google (light)"
+export PROFILE_NAME="Google Light"
 # =============================================
 
 


### PR DESCRIPTION
This updates the Google theme to their official colors: https://github.com/google/vim-colorscheme-primary

I know that the existing theme is based off of the base16 repository (https://github.com/chriskempson/base16).  I would say that it would be worth adding this Google dark and light theme as separate theme if Gogh included the whole base16 ecosystem.  But since it is the only base16 labeled theme, I propose replacing it.  If you disagree, I can resubmit as a separate theme.