### PR TITLE
Fix link to base script in howto docs

### DIFF
--- a/content/howto.md
+++ b/content/howto.md
@@ -15,7 +15,7 @@ Please feel free to use and create your own color schemes.
 
 - **The Script**
 
-https://github.com/Mayccoll/Gogh/blob/master/themes/_base.sh
+https://github.com/Mayccoll/Gogh/blob/master/_base.sh
 
 - **Variables**
 


### PR DESCRIPTION
This pull request fixes a link to the _base script in the howto docs. Initially it was pointing to /themes/_base.sh, but at some point this script was moved to /_base.sh
