### PR TITLE
Mark data/themes.json as a binary file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/themes.json binary


### PR DESCRIPTION
This PR adds a .gitattributes file that marks *data/themes.json* as binary. *data/themes.json* stores all it's data on a single line, and that entire line is marked as changed between commits. By marking it as binary, git displays diffs more accurately.

For example, instead of printing out the entirety of *data/themes.json*, git will instead say "Binary files *version 1* *version 2* differ"

**NB:** As an alternative to marking it as binary, we could also modify *tools/generate.sh* so that it doesn't generate the entire file on one line. This can be done by removing the `tr -d " \t\n\r"` portion of the script. Doing so would ensure that git only stored the sections of the themes.json file that changed when a theme was modified or added.
