### PR TITLE
Increase Usability and Consistency of Nord Light

### DIFF
--- a/themes/nord-light.sh
+++ b/themes/nord-light.sh
@@ -7,7 +7,7 @@ export COLOR_03="#069F5F" #green
 export COLOR_04="#DAB752" #yellow
 export COLOR_05="#439ECF" #blue
 export COLOR_06="#D961DC" #magenta
-export COLOR_07="#64AAAF" #cyan
+export COLOR_07="#00B1BE" #cyan
 export COLOR_08="#B3B3B3" #white
 
 export COLOR_09="#3E89A1" #lightBlack

--- a/themes/nord-light.sh
+++ b/themes/nord-light.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 # ====================CONFIG THIS =============================== #
-export COLOR_01="#353535" #black
+export COLOR_01="#003B4E" #black
 export COLOR_02="#E64569" #red
-export COLOR_03="#89D287" #green
+export COLOR_03="#069F5F" #green
 export COLOR_04="#DAB752" #yellow
 export COLOR_05="#439ECF" #blue
 export COLOR_06="#D961DC" #magenta
 export COLOR_07="#64AAAF" #cyan
 export COLOR_08="#B3B3B3" #white
 
-export COLOR_09="#535353" #lightBlack
+export COLOR_09="#3E89A1" #lightBlack
 export COLOR_10="#E4859A" #lightRed
 export COLOR_11="#A2CCA1" #lightGreen
 export COLOR_12="#E1E387" #lightYellow


### PR DESCRIPTION
Update Nord Light theme to improve usability and make the black and grey colors a dark blue.

Prior to this change, it was extremely difficult to read green text with Nord Light because the green was such a light color that the text was hard to discern against the background.

Green text is common in the output of commands like `git diff`, and many zsh themes use green text to indicate the existence of a command. This commit  updates Nord Light to use a darker green that's still in line with the theme.

This PR also updates Black to be dark blue, and Grey to be blue-grey. Using dark blue and blue-grey colors for Black and Grey respectively is more in line with the style choices made by the Nord theme. I've provided relevant before and after shots below, with the previous version being on the left. 

Before vs After:

![image](https://user-images.githubusercontent.com/36810712/139770418-f8af0673-7057-4b84-9ba3-0bdbc9eb64a2.png)
![image](https://user-images.githubusercontent.com/36810712/139770535-78a45628-3cf8-44dc-bafa-d500fbfe625c.png)
