### PR TITLE
Added support for Konsole

### DIFF
--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -996,6 +996,7 @@ case "${TERMINAL}" in
     "   xfce4-terminal"                                       \
     "   foot"                                                 \
     "   kitty"                                                \
+    "   konsole"                                              \
     ""                                                        \
     "If you believe you have recieved this message in error," \
     "try manually setting \`TERMINAL', hint: ps -h -o comm -p \$PPID"

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -540,6 +540,13 @@ apply_kitty() {
   echo "Done - please reopen your kitty terminal to see the changes"
 }
 
+apply_konsole() {
+  # |
+  # | Applying values on Konsole
+  # | ===========================================
+  
+}
+
 apply_darwin() {
   # |
   # | Applying values on iTerm2
@@ -896,6 +903,10 @@ case "${TERMINAL}" in
 
   kitty )
     apply_kitty
+    ;;
+
+  konsole )
+    apply_konsole
     ;;
 
   * )

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -130,6 +130,14 @@ case "${TERMINAL}" in
       exit 1
     fi
     ;;
+
+  konsole )
+    CFGFILE="${HOME}/.config/konsolerc"
+    if [[ ! -f "${CFGFILE}" ]]; then
+      printf '\n%s\n' "Error: Couldn't find an existing configuration file for Konsole."
+      exit 1
+    fi
+    ;;
 esac
 
 
@@ -565,38 +573,50 @@ apply_konsole() {
   # | Applying values on Konsole
   # | ===========================================
 
+  PARENT=$(grep -o "^DefaultProfile=.*$" ${CFGFILE} | cut -d '=' -f 2)
+  if [[ -z "${PARENT}" ]]; then
+    PARENT="FALLBACK/"
+  fi
+
   if [[ -z "${XDG_DATA_HOME:-}" ]]; then
     KDIR="${HOME}/.local/share/konsole"
   else
 	KDIR="${XDG_DATA_HOME}/konsole"
   fi
 
-  KPROFILE="${KDIR}/${PROFILE_NAME}.colorscheme"
-  echo "Updating color theme file (${KPROFILE}) with theme ..."
+  KPROFILE="${KDIR}/${PROFILE_NAME}.profile"
   if [[ -f "${KPROFILE}" ]]; then
       echo "Profile ${PROFILE_NAME} already exists in Konsole confiuration (${KONSOLE_DIR}); Skipping ..."
       exit 0
   fi
 
   touch "${KPROFILE}"
-  createKonsoleTriple "Background" "${BACKGROUND_COLOR}" "${BACKGROUND_COLOR}" >> "${KPROFILE}"
-  createKonsoleTriple "Color0" "${COLOR_01}" "${COLOR_09}" >> "${KPROFILE}"
-  createKonsoleTriple "Color1" "${COLOR_02}" "${COLOR_10}" >> "${KPROFILE}"
-  createKonsoleTriple "Color2" "${COLOR_03}" "${COLOR_11}" >> "${KPROFILE}"
-  createKonsoleTriple "Color3" "${COLOR_04}" "${COLOR_12}" >> "${KPROFILE}"
-  createKonsoleTriple "Color4" "${COLOR_05}" "${COLOR_13}" >> "${KPROFILE}"
-  createKonsoleTriple "Color5" "${COLOR_06}" "${COLOR_14}" >> "${KPROFILE}"
-  createKonsoleTriple "Color6" "${COLOR_07}" "${COLOR_15}" >> "${KPROFILE}"
-  createKonsoleTriple "Color7" "${COLOR_08}" "${COLOR_16}" >> "${KPROFILE}"
-  createKonsoleTriple "Foreground" "${FOREGROUND_COLOR}" "${FOREGROUND_COLOR}" >> "${KPROFILE}"
-  echo "[General]" >> "${KPROFILE}"
-  echo "Blur=false" >> "${KPROFILE}"
-  echo "ColorRandomization=false" >> "${KPROFILE}"
-  echo "Description=${PROFILE_NAME}" >> "${KPROFILE}"
-  echo "Opacity=1" >> "${KPROFILE}"
-  echo "Wallpaper=" >> "${KPROFILE}"
+  echo -e "[Appearance]\nColorScheme=${PROFILE_NAME}\n" >> "${KPROFILE}"
+  echo -e "[General]\nName=${PROFILE_NAME}\nParent=$PARENT" >> "${KPROFILE}"
 
-  echo "Done - please change your profile by going to Settings > Manage Profiles... > Edit... > Appearance"
+  KCOLORSCHEME="${KDIR}/${PROFILE_NAME}.colorscheme"
+  if [[ -f "${KCOLORSCHEME}" ]]; then
+      echo "Color Scheme ${PROFILE_NAME} already exists in Konsole confiuration (${KONSOLE_DIR}); Skipping ..."
+      exit 0
+  fi
+
+  touch "${KCOLORSCHEME}"
+  createKonsoleTriple "Background" "${BACKGROUND_COLOR}" "${BACKGROUND_COLOR}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color0" "${COLOR_01}" "${COLOR_09}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color1" "${COLOR_02}" "${COLOR_10}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color2" "${COLOR_03}" "${COLOR_11}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color3" "${COLOR_04}" "${COLOR_12}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color4" "${COLOR_05}" "${COLOR_13}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color5" "${COLOR_06}" "${COLOR_14}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color6" "${COLOR_07}" "${COLOR_15}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Color7" "${COLOR_08}" "${COLOR_16}" >> "${KCOLORSCHEME}"
+  createKonsoleTriple "Foreground" "${FOREGROUND_COLOR}" "${FOREGROUND_COLOR}" >> "${KCOLORSCHEME}"
+  echo "[General]" >> "${KCOLORSCHEME}"
+  echo "Blur=false" >> "${KCOLORSCHEME}"
+  echo "ColorRandomization=false" >> "${KCOLORSCHEME}"
+  echo "Description=${PROFILE_NAME}" >> "${KCOLORSCHEME}"
+  echo "Opacity=1" >> "${KCOLORSCHEME}"
+  echo "Wallpaper=" >> "${KCOLORSCHEME}"
 }
 
 apply_darwin() {


### PR DESCRIPTION
I am a long-time user of Gogh, but I have recently hopped distros and am now using KDE + Konsole. As such, I decided to add Konsole support (and by extension yaquake support).

I have mostly copied the code style from the kitty and mintty functions: `apply_konsole` is based on `apply_kitty`, and `createKonsoleEntry` and `createKonsoleTriple` are based on `createMinttyEntry`.

Several issues I encountered while developing this:

1. Konsole has very extensive profiles, meaning that the profiles also store information about font, keybinds, tabs, etc. In my implementation, every profile that is generated by Gogh sets the current default profile as its 'parent', meaning that the Gogh profiles don't have to specify fonts.
2. `${TERMINAL}` gets set to `konsole` using the automatic `ps` script.
3. Konsole separates profiles from colorschemes. To this extent, Gogh creates both a `.colorscheme` and a `.profile` file, as this is more convenient for the user. I was considering making this behaviour optional using an environment variable.
4. Konsole has three color types: normal, faint, and intense. Gogh only specifies ANSI colors. I have mapped `COLOR_01` to `COLOR_08` to normal and faint, and `COLOR_09` to `COLOR_16` to intense.
5. Konsole doesn't seem to be using any environment variables to set configuration directories other than `${XDG_DATA_HOME}`.

I have tested it on my own system (Void Linux with Konsole `21.12.0`), but not on other systems yet.

----
P.S.: It also seems like my text editor automatically removed some redundant spaces - tell me if that is a problem.